### PR TITLE
Add player control buttons with new message

### DIFF
--- a/src/commands/music/play.ts
+++ b/src/commands/music/play.ts
@@ -30,14 +30,15 @@ export class UserCommand extends Command {
 		// defer interaction to avoid timeout
 		await interaction.deferReply();
 
-		try {
-			const { track } = await player.play(channel, query, {
-				nodeOptions: {
-					// for the guild node (queue)
-					metadata: interaction, // access later using queue.metadata
-					volume: 25
-				}
-			});
+                try {
+                        const { track } = await player.play(channel, query, {
+                                requestedBy: interaction.user,
+                                nodeOptions: {
+                                        // for the guild node (queue)
+                                        metadata: interaction, // access later using queue.metadata
+                                        volume: 25
+                                }
+                        });
 
 			return interaction.followUp(`added **${track.url}** to the queue <3`);
 		} catch (e) {

--- a/src/listeners/playerControls.ts
+++ b/src/listeners/playerControls.ts
@@ -1,0 +1,45 @@
+import { Listener } from '@sapphire/framework';
+import { ButtonInteraction } from 'discord.js';
+import { QueueRepeatMode, useMainPlayer } from 'discord-player';
+
+export class PlayerControlsListener extends Listener {
+    public constructor(context: Listener.LoaderContext, options: Listener.Options) {
+        super(context, { ...options, event: 'interactionCreate' });
+    }
+
+    public async run(interaction: ButtonInteraction) {
+        if (!interaction.isButton()) return;
+        const player = useMainPlayer();
+        const queue = player.nodes.get(interaction.guildId!);
+        if (!queue) return;
+
+        switch (interaction.customId) {
+            case 'player_skip':
+                queue.node.skip();
+                return interaction.reply({ content: '⏭️ Skipped', ephemeral: true });
+            case 'player_pause':
+                if (queue.node.isPaused()) {
+                    queue.node.resume();
+                    return interaction.reply({ content: '▶️ Resumed', ephemeral: true });
+                }
+                queue.node.pause();
+                return interaction.reply({ content: '⏸️ Paused', ephemeral: true });
+            case 'player_repeat':
+                const newMode =
+                    queue.repeatMode === QueueRepeatMode.TRACK ? QueueRepeatMode.OFF : QueueRepeatMode.TRACK;
+                queue.setRepeatMode(newMode);
+                return interaction.reply({
+                    content: newMode === QueueRepeatMode.TRACK ? '🔂 Repeat enabled' : '🔂 Repeat disabled',
+                    ephemeral: true
+                });
+            case 'player_seek_forward':
+                await queue.node.seek(queue.node.streamTime + 10000);
+                return interaction.reply({ content: '⏩ Forward 10s', ephemeral: true });
+            case 'player_seek_back':
+                await queue.node.seek(Math.max(queue.node.streamTime - 10000, 0));
+                return interaction.reply({ content: '⏪ Back 10s', ephemeral: true });
+            default:
+                return;
+        }
+    }
+}

--- a/src/listeners/playerStart.ts
+++ b/src/listeners/playerStart.ts
@@ -15,7 +15,14 @@
 
 import { container, Listener } from '@sapphire/framework';
 import type { GuildQueue, Track } from 'discord-player';
-import { GuildTextBasedChannel } from 'discord.js';
+import {
+       ActionRowBuilder,
+       ButtonBuilder,
+       ButtonStyle,
+       EmbedBuilder,
+       type ChatInputCommandInteraction,
+       type GuildTextBasedChannel
+} from 'discord.js';
 
 export class PlayerEvent extends Listener {
 	public constructor(context: Listener.LoaderContext, options: Listener.Options) {
@@ -26,7 +33,31 @@ export class PlayerEvent extends Listener {
 		});
 	}
 
-	public run(queue: GuildQueue<{ channel: GuildTextBasedChannel }>, track: Track) {
-		return queue.metadata.channel.send(`💿 | now playing: **${track.title || 'Unknown Title'}**`);
-	}
+        public run(queue: GuildQueue<ChatInputCommandInteraction>, track: Track) {
+                const interaction = queue.metadata;
+                const channel = interaction.channel as GuildTextBasedChannel | null;
+                if (!channel) return;
+
+                const embed = new EmbedBuilder()
+                        .setDescription(`[${track.title}](${track.url})`)
+                        .setThumbnail(track.thumbnail)
+                        .addFields({ name: 'Queue Length', value: String(queue.tracks.size) });
+
+                const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
+                        new ButtonBuilder().setCustomId('player_skip').setLabel('Skip').setStyle(ButtonStyle.Secondary),
+                        new ButtonBuilder()
+                                .setCustomId('player_pause')
+                                .setLabel(queue.node.isPaused() ? 'Play' : 'Pause')
+                                .setStyle(ButtonStyle.Secondary),
+                        new ButtonBuilder().setCustomId('player_repeat').setLabel('Repeat Song').setStyle(ButtonStyle.Secondary),
+                        new ButtonBuilder().setCustomId('player_seek_forward').setLabel('Seek +10s').setStyle(ButtonStyle.Secondary),
+                        new ButtonBuilder().setCustomId('player_seek_back').setLabel('Seek -10s').setStyle(ButtonStyle.Secondary)
+                );
+
+                return channel.send({
+                        content: `<@${interaction.user.id}>`,
+                        embeds: [embed],
+                        components: [row]
+                });
+        }
 }


### PR DESCRIPTION
## Summary
- send a rich player message when a new track starts
- allow controlling playback with buttons
- register the requester when starting playback

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6857789d48ac832389efc9180aa9ecfe