### PR TITLE
Edit existing now-playing embed instead of sending new one

### DIFF
--- a/src/listeners/playerStart.ts
+++ b/src/listeners/playerStart.ts
@@ -16,15 +16,17 @@
 import { container, Listener } from '@sapphire/framework';
 import type { GuildQueue, Track } from 'discord-player';
 import {
-       ActionRowBuilder,
-       ButtonBuilder,
-       ButtonStyle,
-       EmbedBuilder,
-       type ChatInputCommandInteraction,
-       type GuildTextBasedChannel
+	ActionRowBuilder,
+	ButtonBuilder,
+	ButtonStyle,
+	EmbedBuilder,
+	type ChatInputCommandInteraction,
+	type GuildTextBasedChannel,
+	type Message
 } from 'discord.js';
 
 export class PlayerEvent extends Listener {
+	private readonly lastMessages = new Map<string, Message>();
 	public constructor(context: Listener.LoaderContext, options: Listener.Options) {
 		super(context, {
 			...options,
@@ -33,31 +35,51 @@ export class PlayerEvent extends Listener {
 		});
 	}
 
-        public run(queue: GuildQueue<ChatInputCommandInteraction>, track: Track) {
-                const interaction = queue.metadata;
-                const channel = interaction.channel as GuildTextBasedChannel | null;
-                if (!channel) return;
+	public async run(queue: GuildQueue<ChatInputCommandInteraction>, track: Track) {
+		const interaction = queue.metadata;
+		const channel = interaction.channel as GuildTextBasedChannel | null;
+		if (!channel) return;
 
-                const embed = new EmbedBuilder()
-                        .setDescription(`[${track.title}](${track.url})`)
-                        .setThumbnail(track.thumbnail)
-                        .addFields({ name: 'Queue Length', value: String(queue.tracks.size) });
+		const embed = new EmbedBuilder()
+			.setDescription(`[${track.title}](${track.url})`)
+			.setThumbnail(track.thumbnail)
+			.addFields({ name: 'Queue Length', value: String(queue.tracks.size) });
 
-                const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
-                        new ButtonBuilder().setCustomId('player_skip').setLabel('Skip').setStyle(ButtonStyle.Secondary),
-                        new ButtonBuilder()
-                                .setCustomId('player_pause')
-                                .setLabel(queue.node.isPaused() ? 'Play' : 'Pause')
-                                .setStyle(ButtonStyle.Secondary),
-                        new ButtonBuilder().setCustomId('player_repeat').setLabel('Repeat Song').setStyle(ButtonStyle.Secondary),
-                        new ButtonBuilder().setCustomId('player_seek_forward').setLabel('Seek +10s').setStyle(ButtonStyle.Secondary),
-                        new ButtonBuilder().setCustomId('player_seek_back').setLabel('Seek -10s').setStyle(ButtonStyle.Secondary)
-                );
+		const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
+			new ButtonBuilder().setCustomId('player_skip').setLabel('Skip').setStyle(ButtonStyle.Secondary),
+			new ButtonBuilder()
+				.setCustomId('player_pause')
+				.setLabel(queue.node.isPaused() ? 'Play' : 'Pause')
+				.setStyle(ButtonStyle.Secondary),
+			new ButtonBuilder().setCustomId('player_repeat').setLabel('Repeat Song').setStyle(ButtonStyle.Secondary),
+			new ButtonBuilder().setCustomId('player_seek_forward').setLabel('Seek +10s').setStyle(ButtonStyle.Secondary),
+			new ButtonBuilder().setCustomId('player_seek_back').setLabel('Seek -10s').setStyle(ButtonStyle.Secondary)
+		);
 
-                return channel.send({
-                        content: `<@${interaction.user.id}>`,
-                        embeds: [embed],
-                        components: [row]
-                });
-        }
+		const previousMessage = this.lastMessages.get(channel.id);
+
+		if (previousMessage) {
+			try {
+				const [latest] = Array.from((await channel.messages.fetch({ limit: 1 })).values());
+				if (latest && latest.id === previousMessage.id) {
+					await previousMessage.edit({
+						content: `<@${interaction.user.id}>`,
+						embeds: [embed],
+						components: [row]
+					});
+					return;
+				}
+				await previousMessage.delete().catch(() => {});
+			} catch {
+				// ignore errors fetching or deleting
+			}
+		}
+
+		const message = await channel.send({
+			content: `<@${interaction.user.id}>`,
+			embeds: [embed],
+			components: [row]
+		});
+		this.lastMessages.set(channel.id, message);
+	}
 }


### PR DESCRIPTION
## Summary
- improve `playerStart` listener to update the last embed message when a new track starts
- if the last embed message is no longer the most recent in the channel, delete it and send a new one

## Testing
- `yarn install`
- `yarn format`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_6859f7e523c88323aa176046aa7403b9