### PR TITLE
Fix queue message cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ already exist. By default the database is located at
 `./data/word_triggers.db`. You can change this location by setting the
 `SQLITE_PATH` variable in your `.env` file.
 
+Playback controls also store the ID of the currently playing message in a
+`player_messages` table so leftover messages can be cleaned up when the bot
+starts.
+
 ## License
 
 Dedicated to the public domain via the [Unlicense], courtesy of the Sapphire Community and its contributors.

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -23,3 +23,10 @@ db.exec(
                response TEXT NOT NULL
        )`
 );
+
+db.exec(
+	`CREATE TABLE IF NOT EXISTS player_messages (
+               channel_id TEXT PRIMARY KEY,
+               message_id TEXT NOT NULL
+       )`
+);

--- a/src/lib/playerMessages.ts
+++ b/src/lib/playerMessages.ts
@@ -1,0 +1,53 @@
+import type { Client, GuildTextBasedChannel, Message } from 'discord.js';
+import { db } from './database';
+
+const cache = new Map<string, Message>();
+
+export function getCachedMessage(channelId: string): Message | undefined {
+	return cache.get(channelId);
+}
+
+export async function storePlayerMessage(channel: GuildTextBasedChannel, message: Message) {
+	cache.set(channel.id, message);
+	db.prepare('INSERT OR REPLACE INTO player_messages (channel_id, message_id) VALUES (?, ?)').run(channel.id, message.id);
+}
+
+export async function deletePlayerMessage(channel: GuildTextBasedChannel) {
+	const cached = cache.get(channel.id);
+	if (cached) {
+		try {
+			await cached.delete();
+		} catch {
+			// ignore
+		}
+	} else {
+		const row = db.prepare('SELECT message_id FROM player_messages WHERE channel_id = ?').get(channel.id) as { message_id: string } | undefined;
+		if (row) {
+			try {
+				const msg = await channel.messages.fetch(row.message_id);
+				await msg.delete();
+			} catch {
+				// ignore
+			}
+		}
+	}
+	cache.delete(channel.id);
+	db.prepare('DELETE FROM player_messages WHERE channel_id = ?').run(channel.id);
+}
+
+export async function cleanupStalePlayerMessages(client: Client) {
+	const rows = db.prepare('SELECT channel_id, message_id FROM player_messages').all() as { channel_id: string; message_id: string }[];
+	for (const { channel_id, message_id } of rows) {
+		try {
+			const channel = await client.channels.fetch(channel_id);
+			if (channel && channel.isTextBased()) {
+				const msg = await channel.messages.fetch(message_id);
+				await msg.delete().catch(() => {});
+			}
+		} catch {
+			// ignore fetch or delete errors
+		}
+		db.prepare('DELETE FROM player_messages WHERE channel_id = ?').run(channel_id);
+		cache.delete(channel_id);
+	}
+}

--- a/src/listeners/playerStart.ts
+++ b/src/listeners/playerStart.ts
@@ -24,9 +24,9 @@ import {
 	type GuildTextBasedChannel,
 	type Message
 } from 'discord.js';
+import { storePlayerMessage, getCachedMessage } from '../lib/playerMessages';
 
 export class PlayerEvent extends Listener {
-	private readonly lastMessages = new Map<string, Message>();
 	public constructor(context: Listener.LoaderContext, options: Listener.Options) {
 		super(context, {
 			...options,
@@ -56,7 +56,7 @@ export class PlayerEvent extends Listener {
 			new ButtonBuilder().setCustomId('player_seek_back').setLabel('Seek -10s').setStyle(ButtonStyle.Secondary)
 		);
 
-		const previousMessage = this.lastMessages.get(channel.id);
+		const previousMessage = getCachedMessage(channel.id);
 
 		if (previousMessage) {
 			try {
@@ -67,6 +67,7 @@ export class PlayerEvent extends Listener {
 						embeds: [embed],
 						components: [row]
 					});
+					await storePlayerMessage(channel, previousMessage);
 					return;
 				}
 				await previousMessage.delete().catch(() => {});
@@ -80,6 +81,6 @@ export class PlayerEvent extends Listener {
 			embeds: [embed],
 			components: [row]
 		});
-		this.lastMessages.set(channel.id, message);
+		await storePlayerMessage(channel, message);
 	}
 }

--- a/src/listeners/queueEnd.ts
+++ b/src/listeners/queueEnd.ts
@@ -1,0 +1,21 @@
+import { container, Listener } from '@sapphire/framework';
+import type { GuildQueue } from 'discord-player';
+import type { ChatInputCommandInteraction, GuildTextBasedChannel } from 'discord.js';
+import { deletePlayerMessage } from '../lib/playerMessages';
+
+export class QueueEndListener extends Listener {
+	public constructor(context: Listener.LoaderContext, options: Listener.Options) {
+		super(context, {
+			...options,
+			emitter: container.client.player.events,
+			event: 'queueEnd'
+		});
+	}
+
+	public async run(queue: GuildQueue<ChatInputCommandInteraction>) {
+		const interaction = queue.metadata;
+		const channel = interaction.channel as GuildTextBasedChannel | null;
+		if (!channel) return;
+		await deletePlayerMessage(channel);
+	}
+}

--- a/src/listeners/ready.ts
+++ b/src/listeners/ready.ts
@@ -1,5 +1,6 @@
 import { ApplyOptions } from '@sapphire/decorators';
 import { Listener } from '@sapphire/framework';
+import { cleanupStalePlayerMessages } from '../lib/playerMessages';
 import type { StoreRegistryValue } from '@sapphire/pieces';
 import { blue, gray, green, magenta, magentaBright, white, yellow } from 'colorette';
 
@@ -12,6 +13,9 @@ export class UserEvent extends Listener {
 	public override run() {
 		this.printBanner();
 		this.printStoreDebugInformation();
+		void cleanupStalePlayerMessages(this.container.client).catch((err) =>
+			this.container.logger.error(`Failed to cleanup messages: ${String(err)}`)
+		);
 	}
 
 	private printBanner() {


### PR DESCRIPTION
## Summary
- create `player_messages` table for persistent player message tracking
- remove stale player messages on startup
- update player start to store messages
- delete message on queue end
- document new table

## Testing
- `yarn build`
- `yarn format`


------
https://chatgpt.com/codex/tasks/task_e_6859fc6daedc832396d5f99f392e9727