### PR TITLE
Restrict music controls to current voice channel

### DIFF
--- a/src/commands/music/play.ts
+++ b/src/commands/music/play.ts
@@ -5,7 +5,8 @@ import { GuildMember } from 'discord.js';
 
 @ApplyOptions<Command.Options>({
 	name: 'play',
-	description: 'play music!'
+	description: 'play music!',
+	preconditions: ['InVoiceWithBot']
 })
 export class UserCommand extends Command {
 	public override registerApplicationCommands(registry: Command.Registry) {
@@ -22,23 +23,21 @@ export class UserCommand extends Command {
 	public override async chatInputRun(interaction: Command.ChatInputCommandInteraction) {
 		const player = useMainPlayer();
 		if (interaction.member === null) return interaction.reply(`uh oh stinky a bomb will go off now`);
-		const channel = (interaction.member as GuildMember).voice.channel; // weird required cast?
-
-		if (!channel) return interaction.reply("hey dumbass, you aren't in a voice channel."); // check for VC
+		const channel = (interaction.member as GuildMember).voice.channel!; // weird required cast?
 		const query = interaction.options.getString('query', true);
 
 		// defer interaction to avoid timeout
 		await interaction.deferReply();
 
-                try {
-                        const { track } = await player.play(channel, query, {
-                                requestedBy: interaction.user,
-                                nodeOptions: {
-                                        // for the guild node (queue)
-                                        metadata: interaction, // access later using queue.metadata
-                                        volume: 25
-                                }
-                        });
+		try {
+			const { track } = await player.play(channel, query, {
+				requestedBy: interaction.user,
+				nodeOptions: {
+					// for the guild node (queue)
+					metadata: interaction, // access later using queue.metadata
+					volume: 25
+				}
+			});
 
 			return interaction.followUp(`added **${track.url}** to the queue <3`);
 		} catch (e) {

--- a/src/commands/music/queue.ts
+++ b/src/commands/music/queue.ts
@@ -5,7 +5,8 @@ import { GuildMember } from 'discord.js';
 
 @ApplyOptions<Command.Options>({
 	name: 'queue',
-	description: 'display the current music queue'
+	description: 'display the current music queue',
+	preconditions: ['InVoiceWithBot']
 })
 export class UserCommand extends Command {
 	public override registerApplicationCommands(registry: Command.Registry) {
@@ -15,9 +16,6 @@ export class UserCommand extends Command {
 	public override async chatInputRun(interaction: Command.ChatInputCommandInteraction) {
 		const player = useMainPlayer();
 		if (interaction.member === null) return interaction.reply(`uh oh stinky a bomb will go off now`);
-		const channel = (interaction.member as GuildMember).voice.channel;
-
-		if (!channel) return interaction.reply("hey dumbass, you aren't in a voice channel.");
 
 		const queue = player.nodes.get(interaction.guild!);
 		if (!queue || !queue.node.isPlaying()) return interaction.reply('there is nothing playing right now.');

--- a/src/commands/music/skip.ts
+++ b/src/commands/music/skip.ts
@@ -5,7 +5,8 @@ import { GuildMember } from 'discord.js';
 
 @ApplyOptions<Command.Options>({
 	name: 'skip',
-	description: 'skip the current song'
+	description: 'skip the current song',
+	preconditions: ['InVoiceWithBot']
 })
 export class UserCommand extends Command {
 	public override registerApplicationCommands(registry: Command.Registry) {
@@ -15,9 +16,6 @@ export class UserCommand extends Command {
 	public override async chatInputRun(interaction: Command.ChatInputCommandInteraction) {
 		const player = useMainPlayer();
 		if (interaction.member === null) return interaction.reply(`uh oh stinky a bomb will go off now`);
-		const channel = (interaction.member as GuildMember).voice.channel;
-
-		if (!channel) return interaction.reply("hey dumbass, you aren't in a voice channel.");
 
 		const queue = player.nodes.get(interaction.guild!);
 		if (!queue || !queue.node.isPlaying()) return interaction.reply('there is nothing playing right now.');

--- a/src/commands/music/skipto.ts
+++ b/src/commands/music/skipto.ts
@@ -5,7 +5,8 @@ import { GuildMember } from 'discord.js';
 
 @ApplyOptions<Command.Options>({
 	name: 'skipto',
-	description: 'skip to a specific song in the queue'
+	description: 'skip to a specific song in the queue',
+	preconditions: ['InVoiceWithBot']
 })
 export class UserCommand extends Command {
 	public override registerApplicationCommands(registry: Command.Registry) {
@@ -20,9 +21,6 @@ export class UserCommand extends Command {
 	public override async chatInputRun(interaction: Command.ChatInputCommandInteraction) {
 		const player = useMainPlayer();
 		if (interaction.member === null) return interaction.reply(`uh oh stinky a bomb will go off now`);
-		const channel = (interaction.member as GuildMember).voice.channel;
-
-		if (!channel) return interaction.reply("hey dumbass, you aren't in a voice channel.");
 
 		const queue = player.nodes.get(interaction.guild!);
 		if (!queue || !queue.node.isPlaying()) return interaction.reply('there is nothing playing right now.');

--- a/src/listeners/playerControls.ts
+++ b/src/listeners/playerControls.ts
@@ -1,45 +1,56 @@
 import { Listener } from '@sapphire/framework';
-import { ButtonInteraction } from 'discord.js';
+import { ButtonInteraction, GuildMember } from 'discord.js';
 import { QueueRepeatMode, useMainPlayer } from 'discord-player';
 
 export class PlayerControlsListener extends Listener {
-    public constructor(context: Listener.LoaderContext, options: Listener.Options) {
-        super(context, { ...options, event: 'interactionCreate' });
-    }
+	public constructor(context: Listener.LoaderContext, options: Listener.Options) {
+		super(context, { ...options, event: 'interactionCreate' });
+	}
 
-    public async run(interaction: ButtonInteraction) {
-        if (!interaction.isButton()) return;
-        const player = useMainPlayer();
-        const queue = player.nodes.get(interaction.guildId!);
-        if (!queue) return;
+	public async run(interaction: ButtonInteraction) {
+		if (!interaction.isButton()) return;
+		if (!interaction.inCachedGuild()) return;
+		const member = interaction.member as GuildMember;
+		const voice = member.voice.channel;
+		const botVoice = interaction.guild.members.me?.voice.channel;
 
-        switch (interaction.customId) {
-            case 'player_skip':
-                queue.node.skip();
-                return interaction.reply({ content: '⏭️ Skipped', ephemeral: true });
-            case 'player_pause':
-                if (queue.node.isPaused()) {
-                    queue.node.resume();
-                    return interaction.reply({ content: '▶️ Resumed', ephemeral: true });
-                }
-                queue.node.pause();
-                return interaction.reply({ content: '⏸️ Paused', ephemeral: true });
-            case 'player_repeat':
-                const newMode =
-                    queue.repeatMode === QueueRepeatMode.TRACK ? QueueRepeatMode.OFF : QueueRepeatMode.TRACK;
-                queue.setRepeatMode(newMode);
-                return interaction.reply({
-                    content: newMode === QueueRepeatMode.TRACK ? '🔂 Repeat enabled' : '🔂 Repeat disabled',
-                    ephemeral: true
-                });
-            case 'player_seek_forward':
-                await queue.node.seek(queue.node.streamTime + 10000);
-                return interaction.reply({ content: '⏩ Forward 10s', ephemeral: true });
-            case 'player_seek_back':
-                await queue.node.seek(Math.max(queue.node.streamTime - 10000, 0));
-                return interaction.reply({ content: '⏪ Back 10s', ephemeral: true });
-            default:
-                return;
-        }
-    }
+		if (!voice || !botVoice || voice.id !== botVoice.id) {
+			return interaction.reply({
+				content: 'Join my voice channel to use the player controls.',
+				ephemeral: true
+			});
+		}
+
+		const player = useMainPlayer();
+		const queue = player.nodes.get(interaction.guildId!);
+		if (!queue) return;
+
+		switch (interaction.customId) {
+			case 'player_skip':
+				queue.node.skip();
+				return interaction.reply({ content: '⏭️ Skipped', ephemeral: true });
+			case 'player_pause':
+				if (queue.node.isPaused()) {
+					queue.node.resume();
+					return interaction.reply({ content: '▶️ Resumed', ephemeral: true });
+				}
+				queue.node.pause();
+				return interaction.reply({ content: '⏸️ Paused', ephemeral: true });
+			case 'player_repeat':
+				const newMode = queue.repeatMode === QueueRepeatMode.TRACK ? QueueRepeatMode.OFF : QueueRepeatMode.TRACK;
+				queue.setRepeatMode(newMode);
+				return interaction.reply({
+					content: newMode === QueueRepeatMode.TRACK ? '🔂 Repeat enabled' : '🔂 Repeat disabled',
+					ephemeral: true
+				});
+			case 'player_seek_forward':
+				await queue.node.seek(queue.node.streamTime + 10000);
+				return interaction.reply({ content: '⏩ Forward 10s', ephemeral: true });
+			case 'player_seek_back':
+				await queue.node.seek(Math.max(queue.node.streamTime - 10000, 0));
+				return interaction.reply({ content: '⏪ Back 10s', ephemeral: true });
+			default:
+				return;
+		}
+	}
 }

--- a/src/preconditions/InVoiceWithBot.ts
+++ b/src/preconditions/InVoiceWithBot.ts
@@ -1,0 +1,40 @@
+import { AllFlowsPrecondition } from '@sapphire/framework';
+import type { CommandInteraction, ContextMenuCommandInteraction, Message } from 'discord.js';
+import { GuildMember } from 'discord.js';
+
+export class UserPrecondition extends AllFlowsPrecondition {
+	#noVoice = "hey dumbass, you aren't in a voice channel.";
+	#wrongChannel = 'join my voice channel to control the player.';
+
+	public override chatInputRun(interaction: CommandInteraction) {
+		return this.shared(interaction);
+	}
+
+	public override contextMenuRun(interaction: ContextMenuCommandInteraction) {
+		return this.shared(interaction);
+	}
+
+	public override messageRun(message: Message) {
+		if (!(message.member instanceof GuildMember)) return this.error({ message: this.#noVoice });
+		return this.checkMember(message.member);
+	}
+
+	private shared(interaction: CommandInteraction | ContextMenuCommandInteraction) {
+		if (!interaction.inCachedGuild()) return this.error({ message: this.#noVoice });
+		return this.checkMember(interaction.member as GuildMember);
+	}
+
+	private checkMember(member: GuildMember) {
+		const userChannel = member.voice.channel;
+		if (!userChannel) return this.error({ message: this.#noVoice });
+		const botChannel = member.guild.members.me?.voice.channel;
+		if (botChannel && botChannel.id !== userChannel.id) return this.error({ message: this.#wrongChannel });
+		return this.ok();
+	}
+}
+
+declare module '@sapphire/framework' {
+	interface Preconditions {
+		InVoiceWithBot: never;
+	}
+}


### PR DESCRIPTION
## Summary
- restrict player controls to users in the same voice channel
- block music commands from users not sharing the bot's voice channel using a precondition

## Testing
- `yarn format`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68609d3685848323b46b6cc02f588c4e