### PR TITLE
Use emoji controls and sync pause state

### DIFF
--- a/src/lib/playerButtons.ts
+++ b/src/lib/playerButtons.ts
@@ -1,0 +1,15 @@
+import { ActionRowBuilder, ButtonBuilder, ButtonStyle, type ChatInputCommandInteraction } from 'discord.js';
+import type { GuildQueue } from 'discord-player';
+
+export function buildPlayerRow(queue: GuildQueue<ChatInputCommandInteraction>) {
+	return new ActionRowBuilder<ButtonBuilder>().addComponents(
+		new ButtonBuilder().setCustomId('player_skip').setEmoji('⏭️').setStyle(ButtonStyle.Secondary),
+		new ButtonBuilder()
+			.setCustomId('player_pause')
+			.setEmoji(queue.node.isPaused() ? '▶️' : '⏸️')
+			.setStyle(ButtonStyle.Secondary),
+		new ButtonBuilder().setCustomId('player_repeat').setEmoji('🔂').setStyle(ButtonStyle.Secondary),
+		new ButtonBuilder().setCustomId('player_seek_forward').setEmoji('⏩').setStyle(ButtonStyle.Secondary),
+		new ButtonBuilder().setCustomId('player_seek_back').setEmoji('⏪').setStyle(ButtonStyle.Secondary)
+	);
+}

--- a/src/listeners/playerControls.ts
+++ b/src/listeners/playerControls.ts
@@ -1,6 +1,8 @@
 import { Listener } from '@sapphire/framework';
 import { ButtonInteraction, GuildMember } from 'discord.js';
 import { QueueRepeatMode, useMainPlayer } from 'discord-player';
+import { buildPlayerRow } from '../lib/playerButtons';
+import { getCachedMessage } from '../lib/playerMessages';
 
 export class PlayerControlsListener extends Listener {
 	public constructor(context: Listener.LoaderContext, options: Listener.Options) {
@@ -32,10 +34,17 @@ export class PlayerControlsListener extends Listener {
 			case 'player_pause':
 				if (queue.node.isPaused()) {
 					queue.node.resume();
-					return interaction.reply({ content: '▶️ Resumed', ephemeral: true });
+					await interaction.reply({ content: '▶️ Resumed', ephemeral: true });
+				} else {
+					queue.node.pause();
+					await interaction.reply({ content: '⏸️ Paused', ephemeral: true });
 				}
-				queue.node.pause();
-				return interaction.reply({ content: '⏸️ Paused', ephemeral: true });
+				const message = getCachedMessage(interaction.channelId);
+				if (message) {
+					const row = buildPlayerRow(queue);
+					await message.edit({ components: [row] }).catch(() => {});
+				}
+				return;
 			case 'player_repeat':
 				const newMode = queue.repeatMode === QueueRepeatMode.TRACK ? QueueRepeatMode.OFF : QueueRepeatMode.TRACK;
 				queue.setRepeatMode(newMode);

--- a/src/listeners/playerStart.ts
+++ b/src/listeners/playerStart.ts
@@ -15,16 +15,9 @@
 
 import { container, Listener } from '@sapphire/framework';
 import type { GuildQueue, Track } from 'discord-player';
-import {
-	ActionRowBuilder,
-	ButtonBuilder,
-	ButtonStyle,
-	EmbedBuilder,
-	type ChatInputCommandInteraction,
-	type GuildTextBasedChannel,
-	type Message
-} from 'discord.js';
+import { EmbedBuilder, type ChatInputCommandInteraction, type GuildTextBasedChannel } from 'discord.js';
 import { storePlayerMessage, getCachedMessage } from '../lib/playerMessages';
+import { buildPlayerRow } from '../lib/playerButtons';
 
 export class PlayerEvent extends Listener {
 	public constructor(context: Listener.LoaderContext, options: Listener.Options) {
@@ -45,16 +38,7 @@ export class PlayerEvent extends Listener {
 			.setThumbnail(track.thumbnail)
 			.addFields({ name: 'Queue Length', value: String(queue.tracks.size) });
 
-		const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
-			new ButtonBuilder().setCustomId('player_skip').setLabel('Skip').setStyle(ButtonStyle.Secondary),
-			new ButtonBuilder()
-				.setCustomId('player_pause')
-				.setLabel(queue.node.isPaused() ? 'Play' : 'Pause')
-				.setStyle(ButtonStyle.Secondary),
-			new ButtonBuilder().setCustomId('player_repeat').setLabel('Repeat Song').setStyle(ButtonStyle.Secondary),
-			new ButtonBuilder().setCustomId('player_seek_forward').setLabel('Seek +10s').setStyle(ButtonStyle.Secondary),
-			new ButtonBuilder().setCustomId('player_seek_back').setLabel('Seek -10s').setStyle(ButtonStyle.Secondary)
-		);
+		const row = buildPlayerRow(queue);
 
 		const previousMessage = getCachedMessage(channel.id);
 


### PR DESCRIPTION
## Summary
- switch player controls to emoji-only buttons
- ensure pause button reflects current player state

## Testing
- `yarn install`
- `yarn build`
- `yarn format`


------
https://chatgpt.com/codex/tasks/task_e_6860a427ae308323afa656d79f1bc8b2