### PR TITLE
Add chaos mode toggle

### DIFF
--- a/src/LyraClient.ts
+++ b/src/LyraClient.ts
@@ -8,6 +8,7 @@ import * as Utils from './lib/utils';
 export class LyraClient extends SapphireClient {
 	public override player: Player;
 	public override utils: typeof Utils;
+	public chaosEnabled = false;
 	public constructor() {
 		super({
 			defaultPrefix: '%',
@@ -41,5 +42,6 @@ declare module 'discord.js' {
 	interface Client {
 		readonly player: Player;
 		readonly utils: typeof Utils;
+		chaosEnabled: boolean;
 	}
 }

--- a/src/commands/General/chaos.ts
+++ b/src/commands/General/chaos.ts
@@ -1,0 +1,30 @@
+import { ApplyOptions } from '@sapphire/decorators';
+import { Command, Args } from '@sapphire/framework';
+import type { Message } from 'discord.js';
+
+@ApplyOptions<Command.Options>({
+	description: 'Toggle chaos mode',
+	preconditions: ['OwnerOnly']
+})
+export class ChaosCommand extends Command {
+	public override registerApplicationCommands(registry: Command.Registry) {
+		registry.registerChatInputCommand((builder) =>
+			builder
+				.setName(this.name)
+				.setDescription(this.description)
+				.addBooleanOption((opt) => opt.setName('enabled').setDescription('Enable chaos mode').setRequired(true))
+		);
+	}
+
+	public override async chatInputRun(interaction: Command.ChatInputCommandInteraction) {
+		const enabled = interaction.options.getBoolean('enabled', true);
+		this.container.client.chaosEnabled = enabled;
+		return interaction.reply({ content: `Chaos mode is now ${enabled ? 'enabled' : 'disabled'}.`, ephemeral: true });
+	}
+
+	public override async messageRun(message: Message, args: Args) {
+		const enabled = await args.pick('boolean');
+		this.container.client.chaosEnabled = enabled;
+		return message.reply(`Chaos mode is now ${enabled ? 'enabled' : 'disabled'}.`);
+	}
+}

--- a/src/commands/General/restart.ts
+++ b/src/commands/General/restart.ts
@@ -3,27 +3,24 @@ import { Command } from '@sapphire/framework';
 import type { Message } from 'discord.js';
 
 @ApplyOptions<Command.Options>({
-        name: 'restart',
-        description: 'Restarts the bot',
-        preconditions: ['OwnerOnly']
+	name: 'restart',
+	description: 'Restarts the bot',
+	preconditions: ['OwnerOnly']
 })
 export class RestartCommand extends Command {
-        public override registerApplicationCommands(registry: Command.Registry) {
-                registry.registerChatInputCommand((builder) =>
-                        builder.setName(this.name).setDescription(this.description)
-                );
-        }
+	public override registerApplicationCommands(registry: Command.Registry) {
+		registry.registerChatInputCommand((builder) => builder.setName(this.name).setDescription(this.description));
+	}
 
-        public override async chatInputRun(interaction: Command.ChatInputCommandInteraction) {
-                await interaction.reply({ content: 'Restarting...', ephemeral: true });
-                await this.container.client.destroy();
-                process.exit(0);
-        }
+	public override async chatInputRun(interaction: Command.ChatInputCommandInteraction) {
+		await interaction.reply({ content: 'Restarting...', ephemeral: true });
+		await this.container.client.destroy();
+		process.exit(0);
+	}
 
-        public override async messageRun(message: Message) {
-                await message.reply('Restarting...');
-                await this.container.client.destroy();
-                process.exit(0);
-        }
+	public override async messageRun(message: Message) {
+		await message.reply('Restarting...');
+		await this.container.client.destroy();
+		process.exit(0);
+	}
 }
-

--- a/src/listeners/WordTriggers.ts
+++ b/src/listeners/WordTriggers.ts
@@ -8,7 +8,7 @@ import { db } from '../lib/database';
 })
 export class UserEvent extends Listener {
 	public override async run(message: Message) {
-		if (message.author.bot) return;
+		if (message.author.bot && !this.container.client.chaosEnabled) return;
 
 		const msgText = message.content.toLowerCase();
 


### PR DESCRIPTION
## Summary
- add `chaosEnabled` property to `LyraClient`
- owner-only `/chaos` command toggles whether word triggers ignore the sender
- allow `WordTriggers` listener to respond to bot messages when chaos mode is enabled
- format restart command

## Testing
- `yarn build`
- `yarn format`


------
https://chatgpt.com/codex/tasks/task_e_688533eb58f88323a15d23f9e2cfcb76