### PR TITLE
Use 0ms buffering for seamless track transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ Playback controls also store the ID of the currently playing message in a
 `player_messages` table so leftover messages can be cleaned up when the bot
 starts.
 
+Music playback is configured with a `bufferingTimeout` of `0` to make
+transitions between songs as seamless as possible.
+
 ## License
 
 Dedicated to the public domain via the [Unlicense], courtesy of the Sapphire Community and its contributors.

--- a/src/commands/music/play.ts
+++ b/src/commands/music/play.ts
@@ -30,14 +30,15 @@ export class UserCommand extends Command {
 		await interaction.deferReply();
 
 		try {
-			const { track } = await player.play(channel, query, {
-				requestedBy: interaction.user,
-				nodeOptions: {
-					// for the guild node (queue)
-					metadata: interaction, // access later using queue.metadata
-					volume: 25
-				}
-			});
+                        const { track } = await player.play(channel, query, {
+                                requestedBy: interaction.user,
+                                nodeOptions: {
+                                        // for the guild node (queue)
+                                        metadata: interaction, // access later using queue.metadata
+                                        volume: 25,
+                                        bufferingTimeout: 0
+                                }
+                        });
 
 			return interaction.followUp(`added **${track.url}** to the queue <3`);
 		} catch (e) {


### PR DESCRIPTION
## Summary
- remove default buffering delay so tracks transition immediately
- document zero buffering configuration in README

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_689bda8fc70483238a8f95bdfaf55e8e