### PR TITLE
Fix queue command not showing current track

### DIFF
--- a/src/commands/music/queue.ts
+++ b/src/commands/music/queue.ts
@@ -20,10 +20,13 @@ export class UserCommand extends Command {
 		const queue = player.nodes.get(interaction.guild!);
 		if (!queue || !queue.node.isPlaying()) return interaction.reply('there is nothing playing right now.');
 
+		const currentTrack = queue.currentTrack;
 		const tracks = queue.tracks.toArray();
-		if (tracks.length === 0) return interaction.reply('the queue is currently empty.');
 
-		const description = tracks.map((t, i) => `${i + 1}. **${t.title ?? 'Unknown Title'}**`).join('\n');
+		const description = [
+			`Now Playing: **${currentTrack?.title ?? 'Unknown Title'}**`,
+			...tracks.map((t, i) => `${i + 1}. **${t.title ?? 'Unknown Title'}**`)
+		].join('\n');
 
 		return interaction.reply(`Current Queue:\n${description}`);
 	}


### PR DESCRIPTION
## Summary
- include currently playing track in queue listing

## Testing
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_689bdd9c8d08832391d577591bcf2d68